### PR TITLE
Fixed issue for allowColumnSelection setter

### DIFF
--- a/Classes/TSUIKit/TSTableView/TSTableView.m
+++ b/Classes/TSUIKit/TSTableView/TSTableView.m
@@ -156,7 +156,7 @@
     return _tableHeader.allowColumnSelection;
 }
 
-- (void)setAllowColumnRowSelection:(BOOL)val
+- (void)setAllowColumnSelection:(BOOL)val
 {
     _tableHeader.allowColumnSelection = val;
 }


### PR DESCRIPTION
The setter method for allowColumnSelection had incorrectly been named allowColumnRowSelection, causing a crash on attempting to change this property. This change resolves that issue.
